### PR TITLE
return body as string

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -102,8 +102,8 @@ class Response implements ResponseInterface
      * @author          David Lienhard <github@lienhard.win>
      * @copyright       David Lienhard
      */
-    public function getBody() : string|bool
+    public function getBody() : string
     {
-        return $this->body;
+        return \is_string($this->body) ? $this->body : "";
     }
 }

--- a/src/ResponseInterface.php
+++ b/src/ResponseInterface.php
@@ -86,5 +86,5 @@ interface ResponseInterface
      * @author          David Lienhard <github@lienhard.win>
      * @copyright       David Lienhard
      */
-    public function getBody() : string|bool;
+    public function getBody() : string;
 }


### PR DESCRIPTION
change `getBody()` method of `Response` class to always return a string