### PR TITLE
specify return-type of getWriteFunction

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -140,7 +140,7 @@ class Request implements RequestInterface
      * @author          David Lienhard <github@lienhard.win>
      * @copyright       David Lienhard
      */
-    public function getWriteFunction() : mixed
+    public function getWriteFunction() : callable|null
     {
         return $this->writeFunction;
     }

--- a/src/RequestInterface.php
+++ b/src/RequestInterface.php
@@ -91,7 +91,7 @@ interface RequestInterface
      * @author          David Lienhard <github@lienhard.win>
      * @copyright       David Lienhard
      */
-    public function getWriteFunction() : mixed;
+    public function getWriteFunction() : callable|null;
 
 
     /**


### PR DESCRIPTION
`getWriteFunction()` has to return a `callable` or `null` no `mixed`