### PR TITLE
add strict test for writeFunction type

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -141,6 +141,10 @@ class Request implements RequestInterface
      */
     public function getWriteFunction() : callable|null
     {
+        if (!is_callable($this->writeFunction) && !is_null($this->writeFunction)) {
+            throw new HttpClientException("write function is of invalid type '".gettype($this->writeFunction)."'");
+        }
+
         return $this->writeFunction;
     }
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -9,6 +9,8 @@
 
 namespace DavidLienhard\HttpClient;
 
+use DavidLienhard\HttpClient\Exceptions\HttpClient as HttpClientException;
+
 /**
  * class to set options for the request to send
  *


### PR DESCRIPTION
check if `writeFunction` property is `callable` or `null` before returing it